### PR TITLE
feat: 添加凭证池功能

### DIFF
--- a/src/kmdr/core/bases.py
+++ b/src/kmdr/core/bases.py
@@ -7,11 +7,11 @@ from aiohttp import ClientSession
 from .console import *
 from .error import LoginError
 from .registry import Registry
-from .structure import VolInfo, BookInfo
+from .structure import VolInfo, BookInfo, Credential
 from .utils import construct_callback, async_retry
 from .protocol import AsyncCtxManager
 
-from .context import TerminalContext, SessionContext, UserProfileContext, ConfigContext
+from .context import TerminalContext, SessionContext, ConfigContext
 
 class Configurer(ConfigContext, TerminalContext):
 
@@ -29,7 +29,7 @@ class SessionManager(SessionContext, ConfigContext, TerminalContext):
     @abstractmethod
     async def session(self) -> AsyncCtxManager[ClientSession]: ...
 
-class Authenticator(SessionContext, ConfigContext, UserProfileContext, TerminalContext):
+class Authenticator(SessionContext, ConfigContext, TerminalContext):
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
@@ -38,16 +38,19 @@ class Authenticator(SessionContext, ConfigContext, UserProfileContext, TerminalC
     # 主站正常情况下不使用代理也能登录成功。但是不排除特殊的网络环境下需要代理。
     # 所以暂时保留代理登录的功能，如果后续确认是代理的问题，可以考虑启用 @no_proxy 装饰器。
     # @no_proxy
-    async def authenticate(self) -> None:
+    async def authenticate(self) -> Credential:
         with self._console.status("认证中..."):
             try:
-                assert await async_retry()(self._authenticate)()
+                cred = await async_retry()(self._authenticate)()
+                assert cred is not None
+                self._credential = cred
+                return cred
             except LoginError:
                 info("[red]认证失败。请检查您的登录凭据或会话 cookie。[/red]")
                 raise
 
     @abstractmethod
-    async def _authenticate(self) -> bool: ...
+    async def _authenticate(self) -> Credential: ...
 
 class Lister(SessionContext, TerminalContext):
 
@@ -65,7 +68,7 @@ class Picker(TerminalContext):
     @abstractmethod
     def pick(self, volumes: list[VolInfo]) -> list[VolInfo]: ...
 
-class Downloader(SessionContext, UserProfileContext, TerminalContext):
+class Downloader(SessionContext, TerminalContext):
 
     def __init__(self,
                  dest: str = '.',
@@ -81,14 +84,14 @@ class Downloader(SessionContext, UserProfileContext, TerminalContext):
         self._retry: int = retry
         self._semaphore = asyncio.Semaphore(num_workers)
 
-    async def download(self, book: BookInfo, volumes: list[VolInfo]):
+    async def download(self, cred: Credential, book: BookInfo, volumes: list[VolInfo]):
         if not volumes:
             info("没有可下载的卷。", style="blue")
             return
 
         try:
             with self._progress:
-                tasks = [self._download(book, volume) for volume in volumes]
+                tasks = [self._download(cred, book, volume) for volume in volumes]
                 results = await asyncio.gather(*tasks, return_exceptions=True)
 
             exceptions = [res for res in results if isinstance(res, Exception)]
@@ -103,7 +106,7 @@ class Downloader(SessionContext, UserProfileContext, TerminalContext):
             raise
 
     @abstractmethod
-    async def _download(self, book: BookInfo, volume: VolInfo): ...
+    async def _download(self, cred: Credential, book: BookInfo, volume: VolInfo): ...
 
 SESSION_MANAGER = Registry[SessionManager]('SessionManager', True)
 AUTHENTICATOR = Registry[Authenticator]('Authenticator')

--- a/src/kmdr/core/bases.py
+++ b/src/kmdr/core/bases.py
@@ -11,6 +11,7 @@ from .registry import Registry
 from .structure import VolInfo, BookInfo, Credential
 from .utils import construct_callback, async_retry
 from .protocol import AsyncCtxManager
+from .pool import CredentialPool
 
 from .context import TerminalContext, SessionContext, ConfigContext
 
@@ -21,6 +22,15 @@ class Configurer(ConfigContext, TerminalContext):
     
     @abstractmethod
     def operate(self) -> None: ...
+
+class PoolManager(ConfigContext, TerminalContext):
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self._pool = CredentialPool(self._configurer)
+
+    @abstractmethod
+    async def operate(self) -> None: ...
 
 class SessionManager(SessionContext, ConfigContext, TerminalContext):
 
@@ -129,3 +139,4 @@ LISTERS = Registry[Lister]('Lister')
 PICKERS = Registry[Picker]('Picker')
 DOWNLOADER = Registry[Downloader]('Downloader', True)
 CONFIGURER = Registry[Configurer]('Configurer')
+POOL_MANAGER = Registry[PoolManager]('PoolManager')

--- a/src/kmdr/core/bases.py
+++ b/src/kmdr/core/bases.py
@@ -54,7 +54,6 @@ class Authenticator(SessionContext, ConfigContext, TerminalContext):
             try:
                 cred = await async_retry()(self._authenticate)()
                 assert cred is not None
-                self._credential = cred
                 return cred
             except LoginError:
                 info("[red]认证失败。请检查您的登录凭据或会话 cookie。[/red]")

--- a/src/kmdr/core/console.py
+++ b/src/kmdr/core/console.py
@@ -10,6 +10,8 @@ import io
 from rich.console import Console
 from rich.traceback import Traceback
 
+from .patch import apply_status_patch
+
 _console_config = dict[str, Any](
     log_time_format="[%Y-%m-%d %H:%M:%S]",
 )
@@ -21,6 +23,7 @@ except io.UnsupportedOperation:
     pass
 
 _console = Console(**_console_config)
+apply_status_patch(_console) # Monkey patch
 
 _is_verbose = False
 

--- a/src/kmdr/core/context.py
+++ b/src/kmdr/core/context.py
@@ -3,7 +3,7 @@ from typing import Optional
 from aiohttp import ClientSession
 from rich.progress import Progress
 
-from .defaults import Configurer as InnerConfigurer, UserProfile, session_var, base_url_var, progress_definition
+from .defaults import Configurer as InnerConfigurer, session_var, base_url_var, progress_definition
 from .console import _console
 
 _lazy_progress: Optional[Progress] = None
@@ -20,12 +20,6 @@ class TerminalContext:
         if _lazy_progress is None:
             _lazy_progress = Progress(*progress_definition, console=self._console, refresh_per_second=4)
         return _lazy_progress
-
-class UserProfileContext:
-
-    def __init__(self, *args, **kwargs):
-        super().__init__()
-        self._profile = UserProfile()
 
 class ConfigContext:
 

--- a/src/kmdr/core/defaults.py
+++ b/src/kmdr/core/defaults.py
@@ -93,18 +93,23 @@ def argument_parser():
     pool_add = pool_subparsers.add_parser('add', help='向池中添加账号')
     pool_add.add_argument('-u', '--username', type=str, required=True, help='用户名')
     pool_add.add_argument('-p', '--password', type=str, help='密码')
-    pool_add.add_argument('--order', type=int, default=0, help='账号优先级，数值越小优先级越高')
-    pool_add.add_argument('--note', type=str, help='备注信息')
+    pool_add.add_argument('-o', '--order', type=int, default=0, help='账号优先级，数值越小优先级越高')
+    pool_add.add_argument('-n', '--note', type=str, help='备注信息')
 
     pool_remove = pool_subparsers.add_parser('remove', help='从池中移除账号')
     pool_remove.add_argument('username', type=str, help='要移除的用户名')
 
     pool_list = pool_subparsers.add_parser('list', help='列出池中所有账号')
-    pool_list.add_argument('--refresh', '-r', action='store_true', help='刷新所有账号的状态和配额信息')
+    pool_list.add_argument('-r', '--refresh', action='store_true', help='刷新所有账号的状态和配额信息')
     pool_list.add_argument('--num-workers', type=int, default=3, help='刷新时使用的并发任务数，默认为 3')
 
     pool_use = pool_subparsers.add_parser('use', help='将池中指定账号应用为当前默认账号')
     pool_use.add_argument('username', type=str, help='要切换使用的用户名')
+
+    pool_update = pool_subparsers.add_parser('update', help='更新池中指定账号的信息')
+    pool_update.add_argument('username', type=str, help='要更新的用户名')
+    pool_update.add_argument('-n', '--note', type=str, help='更新备注信息')
+    pool_update.add_argument('-o', '--order', type=int, help='更新账号优先级，数值越小优先级越高')
 
     return parser
 

--- a/src/kmdr/core/defaults.py
+++ b/src/kmdr/core/defaults.py
@@ -72,6 +72,7 @@ def argument_parser():
     download_parser.add_argument('--disable-multi-part', action='store_true', help='禁用分片下载，优先级高于尝试启用分片下载选项')
     download_parser.add_argument('--try-multi-part', action='store_true', help='尝试启用分片下载')
     download_parser.add_argument('--fake-ua', action='store_true', help='使用随机的 User-Agent 进行请求')
+    download_parser.add_argument('--use-pool', action='store_true', help='启用凭证池进行下载')
 
     login_parser = subparsers.add_parser('login', help='登录到 Kmoe')
     login_parser.add_argument('-u', '--username', type=str, help='用户名', required=True)
@@ -86,6 +87,23 @@ def argument_parser():
     config_parser.add_argument('-b', '--base-url', type=str, help='设置镜像站点的基础 URL, 例如: `https://kxx.moe`')
     config_parser.add_argument('-c', '--clear', type=str, help='清除指定配置，可选值为 `all`, `cookie`, `option`')
     config_parser.add_argument('-d', '--delete', '--unset', dest='unset', type=str, help='删除特定的配置选项')
+
+    pool_parser = subparsers.add_parser('pool', help='管理凭证池')
+    
+    pool_subparsers = pool_parser.add_subparsers(title='凭证池操作', dest='pool_command')
+
+    pool_add = pool_subparsers.add_parser('add', help='向池中添加账号')
+    pool_add.add_argument('-u', '--username', type=str, required=True, help='用户名')
+    pool_add.add_argument('-p', '--password', type=str, required=True, help='密码')
+    pool_add.add_argument('--note', type=str, help='备注信息')
+
+    pool_remove = pool_subparsers.add_parser('remove', help='从池中移除账号')
+    pool_remove.add_argument('username', type=str, help='要移除的用户名')
+
+    pool_list = pool_subparsers.add_parser('list', help='列出池中所有账号')
+
+    pool_use = pool_subparsers.add_parser('use', help='将池中指定账号应用为当前默认账号')
+    pool_use.add_argument('username', type=str, help='要切换使用的用户名')
 
     return parser
 

--- a/src/kmdr/core/defaults.py
+++ b/src/kmdr/core/defaults.py
@@ -100,6 +100,8 @@ def argument_parser():
     pool_remove.add_argument('username', type=str, help='要移除的用户名')
 
     pool_list = pool_subparsers.add_parser('list', help='列出池中所有账号')
+    pool_list.add_argument('--refresh', action='store_true', help='刷新所有账号的状态和配额信息')
+    pool_list.add_argument('--num-workers', type=int, default=3, help='刷新时使用的并发任务数，默认为 3')
 
     pool_use = pool_subparsers.add_parser('use', help='将池中指定账号应用为当前默认账号')
     pool_use.add_argument('username', type=str, help='要切换使用的用户名')

--- a/src/kmdr/core/defaults.py
+++ b/src/kmdr/core/defaults.py
@@ -1,14 +1,10 @@
-import io
-import sys
 import os
 import json
 from typing import Optional, Any
 import argparse
 from contextvars import ContextVar
 
-from rich.console import Console
 from rich.progress import (
-    Progress,
     BarColumn,
     DownloadColumn,
     TextColumn,

--- a/src/kmdr/core/defaults.py
+++ b/src/kmdr/core/defaults.py
@@ -70,7 +70,7 @@ def argument_parser():
     download_parser.add_argument('--disable-multi-part', action='store_true', help='禁用分片下载，优先级高于尝试启用分片下载选项')
     download_parser.add_argument('--try-multi-part', action='store_true', help='尝试启用分片下载')
     download_parser.add_argument('--fake-ua', action='store_true', help='使用随机的 User-Agent 进行请求')
-    download_parser.add_argument('--use-pool', action='store_true', help='启用凭证池进行下载')
+    # download_parser.add_argument('--use-pool', action='store_true', help='启用凭证池进行下载')
 
     login_parser = subparsers.add_parser('login', help='登录到 Kmoe')
     login_parser.add_argument('-u', '--username', type=str, help='用户名', required=True)

--- a/src/kmdr/core/defaults.py
+++ b/src/kmdr/core/defaults.py
@@ -15,7 +15,7 @@ from rich.progress import (
 )
 
 from .utils import singleton
-from .structure import Config, Credential, CredentialStatus, Credential, QuotaInfo
+from .structure import Config, Credential, CredentialStatus, QuotaInfo
 from .constants import BASE_URL
 from .console import _update_verbose_setting
 

--- a/src/kmdr/core/defaults.py
+++ b/src/kmdr/core/defaults.py
@@ -84,7 +84,7 @@ def argument_parser():
     config_parser.add_argument('-c', '--clear', type=str, help='清除指定配置，可选值为 `all`, `cookie`, `option`')
     config_parser.add_argument('-d', '--delete', '--unset', dest='unset', type=str, help='删除特定的配置选项')
 
-    pool_parser = subparsers.add_parser('pool', help='管理凭证池')
+    pool_parser = subparsers.add_parser('pool', aliases=['profile'], help='管理凭证池')
     
     pool_subparsers = pool_parser.add_subparsers(title='凭证池操作', dest='pool_command')
 

--- a/src/kmdr/core/defaults.py
+++ b/src/kmdr/core/defaults.py
@@ -90,7 +90,8 @@ def argument_parser():
 
     pool_add = pool_subparsers.add_parser('add', help='向池中添加账号')
     pool_add.add_argument('-u', '--username', type=str, required=True, help='用户名')
-    pool_add.add_argument('-p', '--password', type=str, required=True, help='密码')
+    pool_add.add_argument('-p', '--password', type=str, help='密码')
+    pool_add.add_argument('--order', type=int, default=0, help='账号优先级，数值越小优先级越高')
     pool_add.add_argument('--note', type=str, help='备注信息')
 
     pool_remove = pool_subparsers.add_parser('remove', help='从池中移除账号')
@@ -115,29 +116,6 @@ def parse_args():
         parser.print_help()
 
     return args
-
-@singleton
-class UserProfile:
-
-    def __init__(self):
-        self._is_vip: Optional[int] = None
-        self._user_level: Optional[int] = None
-
-    @property
-    def is_vip(self) -> Optional[int]:
-        return self._is_vip
-
-    @property
-    def user_level(self) -> Optional[int]:
-        return self._user_level
-    
-    @is_vip.setter
-    def is_vip(self, value: Optional[int]):
-        self._is_vip = value
-
-    @user_level.setter
-    def user_level(self, value: Optional[int]):
-        self._user_level = value
 
 @singleton
 class Configurer:

--- a/src/kmdr/core/defaults.py
+++ b/src/kmdr/core/defaults.py
@@ -100,7 +100,7 @@ def argument_parser():
     pool_remove.add_argument('username', type=str, help='要移除的用户名')
 
     pool_list = pool_subparsers.add_parser('list', help='列出池中所有账号')
-    pool_list.add_argument('--refresh', action='store_true', help='刷新所有账号的状态和配额信息')
+    pool_list.add_argument('--refresh', '-r', action='store_true', help='刷新所有账号的状态和配额信息')
     pool_list.add_argument('--num-workers', type=int, default=3, help='刷新时使用的并发任务数，默认为 3')
 
     pool_use = pool_subparsers.add_parser('use', help='将池中指定账号应用为当前默认账号')

--- a/src/kmdr/core/patch.py
+++ b/src/kmdr/core/patch.py
@@ -1,0 +1,58 @@
+from rich.status import Status
+from contextlib import contextmanager
+
+class _StackedStatusManager:
+    def __init__(self, console):
+        self.console = console
+        self._stack = []
+        self._finished = set()
+        self._live_status = None
+
+    def _clean_stack_top(self):
+        while self._stack:
+            token, _ = self._stack[-1]
+            if token in self._finished:
+                self._stack.pop()
+                self._finished.remove(token) 
+            else:
+                break
+
+    def _refresh(self):
+        self._clean_stack_top()
+
+        if not self._stack:
+            self._finished.clear()
+            if self._live_status:
+                self._live_status.stop()
+                self._live_status = None
+        else:
+            _, text = self._stack[-1]
+            if self._live_status is None:
+                self._live_status = Status(text, console=self.console)
+                self._live_status.start()
+            else:
+                self._live_status.update(text)
+
+    @contextmanager
+    def status(self, text):
+        token = object()
+        
+        self._stack.append((token, text))
+        self._refresh()
+        
+        try:
+            yield
+        finally:
+            self._finished.add(token)
+            self._refresh()
+
+def apply_status_patch(console_instance):
+    """
+    为 Console.status() 提供可嵌套支持，避免在 asyncio 并发场景下触发 LiveError。
+
+    前提与限制：
+    - 仅适用于单线程 asyncio 应用
+    - 所有协程必须复用同一个 Console 实例
+    """
+    manager = _StackedStatusManager(console_instance)
+    console_instance.status = manager.status

--- a/src/kmdr/core/pool.py
+++ b/src/kmdr/core/pool.py
@@ -12,6 +12,7 @@ class CredentialPool:
 
     @property
     def pool(self) -> list[Credential]:
+        """返回当前的凭证池列表"""
         return self._config.config.cred_pool or []
 
     def _refresh_iterator(self):
@@ -22,12 +23,14 @@ class CredentialPool:
             self._cycle_iterator = None
     
     def find(self, username: str) -> Optional[Credential]:
+        """根据用户名查找对应的凭证"""
         for cred in self.pool:
             if cred.username == username:
                 return cred
         return None
 
     def add(self, cred: Credential) -> None:
+        """向凭证池中添加新的凭证"""
         if self._config.config.cred_pool is None:
             self._config.config.cred_pool = []
         
@@ -36,12 +39,14 @@ class CredentialPool:
         self._refresh_iterator()
 
     def check_duplicate(self, username: str) -> bool:
+        """检查凭证池中是否已存在指定用户名的凭证"""
         for cred in self.pool:
             if cred.username == username:
                 return True
         return False
 
     def remove(self, username: str) -> bool:
+        """从凭证池中移除指定用户名的凭证"""
         if self._config.config.cred_pool is None:
             return False
         
@@ -54,6 +59,7 @@ class CredentialPool:
         return False
 
     def update(self, username: str, cred: Credential) -> bool:
+        """更新指定用户名的凭证信息"""
         if self._config.config.cred_pool is None:
             return False
         
@@ -66,6 +72,7 @@ class CredentialPool:
         return False
 
     def update_status(self, username: str, status: CredentialStatus) -> bool:
+        """更新指定用户名的凭证状态"""
         if self._config.config.cred_pool is None:
             return False
         
@@ -79,12 +86,14 @@ class CredentialPool:
         return False
 
     def clear(self) -> None:
+        """清空凭证池中的所有凭证"""
         self._config.config.cred_pool = []
         self._config.update()
         self._refresh_iterator()
 
     @property
     def active_creds(self) -> list[Credential]:
+        """返回所有状态为 ACTIVE 的凭证，按优先级排序"""
         creds = [cred for cred in self.pool if cred.status == CredentialStatus.ACTIVE]
         return sorted(creds, key=lambda x: x.order)
 

--- a/src/kmdr/core/pool.py
+++ b/src/kmdr/core/pool.py
@@ -1,0 +1,172 @@
+import time
+from typing import Iterator, Optional
+import itertools
+
+from .defaults import Configurer
+from .structure import Credential, CredentialStatus, QuotaInfo
+
+class CredentialPool:
+    def __init__(self, config: Configurer):
+        self._config = config
+        self._cycle_iterator: Optional[Iterator[Credential]] = None
+
+    @property
+    def pool(self) -> list[Credential]:
+        return self._config.config.cred_pool or []
+
+    def _refresh_iterator(self):
+        active = self.active_creds
+        if active:
+            self._cycle_iterator = itertools.cycle(active)
+        else:
+            self._cycle_iterator = None
+
+    def add(self, cred: Credential) -> None:
+        if self._config.config.cred_pool is None:
+            self._config.config.cred_pool = []
+        
+        self._config.config.cred_pool.append(cred)
+        self._config.update()
+        self._refresh_iterator()
+
+    def check_duplicate(self, username: str) -> bool:
+        for cred in self.pool:
+            if cred.username == username:
+                return True
+        return False
+
+    def remove(self, username: str) -> bool:
+        if self._config.config.cred_pool is None:
+            return False
+        
+        for cred in self._config.config.cred_pool:
+            if cred.username == username:
+                self._config.config.cred_pool.remove(cred)
+                self._config.update()
+                self._refresh_iterator()
+                return True
+        return False
+
+    def update(self, username: str, cred: Credential) -> bool:
+        if self._config.config.cred_pool is None:
+            return False
+        
+        for idx, cre in enumerate(self._config.config.cred_pool):
+            if cre.username == username:
+                self._config.config.cred_pool[idx] = cred
+                self._config.update()
+                self._refresh_iterator()
+                return True
+        return False
+
+    def update_status(self, username: str, status: CredentialStatus) -> bool:
+        if self._config.config.cred_pool is None:
+            return False
+        
+        for cred in self._config.config.cred_pool:
+            if cred.username == username:
+                if cred.status != status:
+                    cred.status = status
+                    self._config.update()
+                    self._refresh_iterator()
+                return True
+        return False
+
+    def clear(self) -> None:
+        self._config.config.cred_pool = []
+        self._config.update()
+        self._refresh_iterator()
+
+    @property
+    def active_creds(self) -> list[Credential]:
+        creds = [cred for cred in self.pool if cred.status == CredentialStatus.ACTIVE]
+        return sorted(creds, key=lambda x: x.order)
+
+    def get_next(self, max_recursion_depth: int = 3) -> Optional[Credential]:
+        if (max_recursion_depth <= 0):
+            return None
+
+        if self._cycle_iterator is None:
+            self._refresh_iterator()
+
+        if self._cycle_iterator is None:
+            return None
+
+        max_attempts = len(self.active_creds) 
+        
+        for _ in range(max_attempts):
+            try:
+                cred = next(self._cycle_iterator)
+                if cred.status == CredentialStatus.ACTIVE:
+                    return cred
+            except StopIteration:
+                self._refresh_iterator()
+                return None
+        
+        self._refresh_iterator()
+        return self.get_next(max_recursion_depth - 1)
+
+class PooledCredential:
+    def __init__(self, credential: Credential):
+        self._cred = credential
+        
+        self._cred.user_quota.reserved = 0.0
+        if self._cred.vip_quota:
+            self._cred.vip_quota.reserved = 0.0
+
+    @property
+    def inner(self) -> Credential:
+        return self._cred
+
+    def _get_target(self, is_vip: bool) -> Optional[QuotaInfo]:
+        if is_vip and self._cred.vip_quota:
+            return self._cred.vip_quota
+        return self._cred.user_quota
+
+    def update_from_server(self, server_cred: Credential):
+        if server_cred.username != self._cred.username:
+            raise ValueError("无法更新凭证：用户名不匹配。")
+
+        self._cred.level = server_cred.level
+        self._cred.nickname = server_cred.nickname
+        self._cred.cookies = server_cred.cookies
+
+        self._overwrite_quota(self._cred.user_quota, server_cred.user_quota)
+        
+        if server_cred.vip_quota:
+            if self._cred.vip_quota:
+                self._overwrite_quota(self._cred.vip_quota, server_cred.vip_quota)
+            else:
+                self._cred.vip_quota = server_cred.vip_quota
+        else:
+            self._cred.vip_quota = None
+
+    def _overwrite_quota(self, local: QuotaInfo, remote: QuotaInfo):
+        local.total = remote.total
+        local.used = remote.used
+        local.reset_day = remote.reset_day
+        local.update_at = time.time()
+        
+        local.unsynced_usage = 0.0
+        
+
+    def reserve(self, size_mb: float, is_vip: bool = True) -> bool:
+        target = self._get_target(is_vip)
+        if target and target.remaining >= size_mb:
+            target.reserved += size_mb
+            return True
+        return False
+
+    def commit(self, size_mb: float, is_vip: bool = True):
+        target = self._get_target(is_vip)
+        if target:
+            target.reserved = max(0.0, target.reserved - size_mb)
+            
+            target.unsynced_usage += size_mb 
+            
+            target.update_at = time.time()
+
+    def rollback(self, size_mb: float, is_vip: bool = True):
+        target = self._get_target(is_vip)
+        if target:
+            target.reserved = max(0.0, target.reserved - size_mb)

--- a/src/kmdr/core/pool.py
+++ b/src/kmdr/core/pool.py
@@ -20,6 +20,12 @@ class CredentialPool:
             self._cycle_iterator = itertools.cycle(active)
         else:
             self._cycle_iterator = None
+    
+    def find(self, username: str) -> Optional[Credential]:
+        for cred in self.pool:
+            if cred.username == username:
+                return cred
+        return None
 
     def add(self, cred: Credential) -> None:
         if self._config.config.cred_pool is None:

--- a/src/kmdr/core/registry.py
+++ b/src/kmdr/core/registry.py
@@ -125,6 +125,9 @@ class Predication:
     def __hash__(self) -> int:
         return hash((self.cls, self.hasattrs, frozenset(self.hasvalues.items()), self.predicate, self.order))
     
-    def __eq__(self, other: 'Predication') -> bool:
+    def __eq__(self, other: object) -> bool:
+        if not isinstance(other, Predication):
+            return False
+
         return (self.cls, self.hasattrs, frozenset(self.hasvalues.items()), self.predicate, self.order) == \
                (other.cls, other.hasattrs, frozenset(other.hasvalues.items()), other.predicate, other.order)

--- a/src/kmdr/core/session.py
+++ b/src/kmdr/core/session.py
@@ -4,7 +4,7 @@ from typing import Type
 from types import TracebackType
 
 import asyncio
-from aiohttp import ClientSession
+from aiohttp import ClientSession, DummyCookieJar
 
 from .constants import BASE_URL, API_ROUTE
 from .utils import async_retry, PrioritySorter, get_random_ua
@@ -67,6 +67,7 @@ class KmdrSessionManager(SessionManager):
                 proxy=self._proxy,
                 trust_env=True,
                 headers=self._headers,
+                cookie_jar=DummyCookieJar(),
             )
 
             return SessionCtxManager(self._session)

--- a/src/kmdr/core/structure.py
+++ b/src/kmdr/core/structure.py
@@ -1,5 +1,6 @@
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from enum import Enum
+import time
 from typing import Optional
 
 class VolumeType(Enum):
@@ -68,3 +69,110 @@ class Config:
     cookie: Optional[dict[str, str]] = None
 
     base_url: Optional[str] = None
+
+    cred_pool: Optional[list['Credential']] = None
+    """
+    凭证池，存储多个账号的凭证信息
+    """
+
+class CredentialStatus(Enum):
+    ACTIVE = "active"
+    """标记凭证为正常状态"""
+
+    INVALID = "invalid"
+    """标记凭证为无效状态"""
+
+    QUOTA_EXCEEDED = "quota_exceeded"
+    """标记凭证为流量用尽状态"""
+
+    DISABLED = "disabled"
+    """标记凭证为禁用状态"""
+
+    TEMPORARILY = "temporarily"
+    """标记凭证为临时的状态"""
+
+@dataclass
+class QuotaInfo:
+
+    reset_day: int
+    """
+    流量重置日, 当日 0 点重置
+    """
+
+    total: float
+    used: float
+
+    reserved: float = 0.0
+    unsynced_usage: float = 0.0
+
+    update_at: float = field(default_factory=time.time)
+
+    @property
+    def remaining(self) -> float:
+        real_remaining = self.total - self.used - self.reserved
+        return max(0.0, real_remaining)
+
+    def reserve(self, amount: float) -> bool:
+        if self.remaining >= amount:
+            self.reserved += amount
+            return True
+        return False
+
+@dataclass
+class Credential:
+
+    username: str
+    """
+    账号用户名，用作唯一标识
+    """
+
+    cookies: dict[str, str]
+
+    user_quota: QuotaInfo
+
+    level: int
+
+    nickname: Optional[str] = None
+
+    vip_quota: Optional[QuotaInfo] = None
+
+    order: int = 0
+
+    status: CredentialStatus = CredentialStatus.ACTIVE
+
+    note: Optional[str] = None
+
+    @property
+    def is_vip(self) -> bool:
+        return self.vip_quota is not None
+
+    @property
+    def quota_remaining(self) -> float:
+        u_rem = self.user_quota.remaining
+        v_rem = self.vip_quota.remaining if self.vip_quota else 0.0
+        return u_rem + v_rem
+
+    def __rich_repr__(self):
+        """对敏感字段进行脱敏"""
+        yield "username", self.username
+        
+        masked_cookies = {}
+        if self.cookies:
+            for k, v in self.cookies.items():
+                if len(v) > 8:
+                    masked_v = f"{v[:2]}******{v[-4:]}"
+                else:
+                    masked_v = "******"
+                masked_cookies[k] = masked_v
+        
+        yield "cookies", masked_cookies
+
+        yield "user_quota", self.user_quota
+        yield "level", self.level
+        yield "nickname", self.nickname
+        yield "vip_quota", self.vip_quota
+        yield "order", self.order
+        yield "status", self.status
+        
+        if self.note:
+            yield "note", self.note

--- a/src/kmdr/core/utils.py
+++ b/src/kmdr/core/utils.py
@@ -88,6 +88,18 @@ def async_retry(
         return wrapper
     return decorator
 
+def extract_cookies(response: aiohttp.ClientResponse) -> dict[str, str]:
+    extracted_cookies: dict[str, str] = {}
+
+    for history_resp in response.history:
+        for key, morsel in history_resp.cookies.items():
+            extracted_cookies[key] = morsel.value
+
+    for key, morsel in response.cookies.items():
+        extracted_cookies[key] = morsel.value
+
+    return extracted_cookies
+
 
 H = TypeVar('H', bound=Hashable)
 class PrioritySorter(Generic[H]):

--- a/src/kmdr/main.py
+++ b/src/kmdr/main.py
@@ -22,11 +22,13 @@ async def main(args: Namespace, fallback: Callable[[], None] = lambda: print('NO
 
     elif args.command == 'login':
         async with (await SESSION_MANAGER.get(args).session()):
-            await AUTHENTICATOR.get(args).authenticate()
+            cred = await AUTHENTICATOR.get(args).authenticate()
+            debug("认证成功，凭证信息: ", cred)
 
     elif args.command == 'status':
         async with (await SESSION_MANAGER.get(args).session()):
-            await AUTHENTICATOR.get(args).authenticate()
+            cred = await AUTHENTICATOR.get(args).authenticate()
+            debug("认证成功，凭证信息: ", cred)
 
     elif args.command == 'download':
         async with (await SESSION_MANAGER.get(args).session()):

--- a/src/kmdr/main.py
+++ b/src/kmdr/main.py
@@ -4,6 +4,7 @@ import asyncio
 
 from kmdr import __version__
 from kmdr.core import *
+from kmdr.core.bases import POOL_MANAGER
 from kmdr.module import *
 
 async def main(args: Namespace, fallback: Callable[[], None] = lambda: print('NOT IMPLEMENTED!')) -> None:
@@ -40,6 +41,9 @@ async def main(args: Namespace, fallback: Callable[[], None] = lambda: print('NO
             debug("选择了", len(volumes), "个章节进行下载:", ', '.join(volume.name for volume in volumes))
 
             await DOWNLOADER.get(args).download(cred, book, volumes)
+    
+    elif args.command == 'pool':
+        await POOL_MANAGER.get(args).operate()
 
     else:
         fallback()

--- a/src/kmdr/main.py
+++ b/src/kmdr/main.py
@@ -29,9 +29,10 @@ async def main(args: Namespace, fallback: Callable[[], None] = lambda: print('NO
 
     elif args.command == 'download':
         async with (await SESSION_MANAGER.get(args).session()):
-            await AUTHENTICATOR.get(args).authenticate()
+            t_auth = AUTHENTICATOR.get(args).authenticate()
+            t_list = LISTERS.get(args).list()
 
-            book, volumes = await LISTERS.get(args).list()
+            _, (book, volumes) = await asyncio.gather(t_auth, t_list)
             debug("获取到书籍《", book.name, "》及其", len(volumes), "个章节信息。")
 
             volumes = PICKERS.get(args).pick(volumes)

--- a/src/kmdr/main.py
+++ b/src/kmdr/main.py
@@ -32,13 +32,14 @@ async def main(args: Namespace, fallback: Callable[[], None] = lambda: print('NO
             t_auth = AUTHENTICATOR.get(args).authenticate()
             t_list = LISTERS.get(args).list()
 
-            _, (book, volumes) = await asyncio.gather(t_auth, t_list)
+            cred, (book, volumes) = await asyncio.gather(t_auth, t_list)
+            debug("认证成功，凭证信息: ", cred)
             debug("获取到书籍《", book.name, "》及其", len(volumes), "个章节信息。")
 
             volumes = PICKERS.get(args).pick(volumes)
             debug("选择了", len(volumes), "个章节进行下载:", ', '.join(volume.name for volume in volumes))
 
-            await DOWNLOADER.get(args).download(book, volumes)
+            await DOWNLOADER.get(args).download(cred, book, volumes)
 
     else:
         fallback()

--- a/src/kmdr/module/__init__.py
+++ b/src/kmdr/module/__init__.py
@@ -3,3 +3,4 @@ from .lister import *
 from .picker import *
 from .downloader import *
 from .configurer import *
+from .pool import *

--- a/src/kmdr/module/authenticator/LoginAuthenticator.py
+++ b/src/kmdr/module/authenticator/LoginAuthenticator.py
@@ -25,7 +25,7 @@ class LoginAuthenticator(Authenticator):
 
         self._password = password
 
-    async def _authenticate(self) -> bool:
+    async def _authenticate(self) -> Credential:
 
         async with self._session.post(
             url = API_ROUTE.LOGIN_DO,
@@ -60,4 +60,4 @@ class LoginAuthenticator(Authenticator):
             )
             self._credential = cred
             self._configurer.cookie = cred.cookies
-            return True
+            return cred

--- a/src/kmdr/module/authenticator/__init__.py
+++ b/src/kmdr/module/authenticator/__init__.py
@@ -1,2 +1,7 @@
 from .CookieAuthenticator import CookieAuthenticator
 from .LoginAuthenticator import LoginAuthenticator
+
+__all__ = [
+    "CookieAuthenticator",
+    "LoginAuthenticator",
+]

--- a/src/kmdr/module/authenticator/utils.py
+++ b/src/kmdr/module/authenticator/utils.py
@@ -1,14 +1,16 @@
-from typing import Optional, Callable
+from typing import Optional, Union
+import re
 
 from aiohttp import ClientSession
 from rich.console import Console
-
+from bs4 import BeautifulSoup, Tag
 from yarl import URL
 
 from kmdr.core.error import LoginError
-from kmdr.core.utils import async_retry
+from kmdr.core.utils import async_retry, extract_cookies
 from kmdr.core.constants import API_ROUTE
 from kmdr.core.console import *
+from kmdr.core.structure import Credential, QuotaInfo
 
 NICKNAME_ID = 'div_nickname_display'
 
@@ -16,29 +18,30 @@ VIP_ID = 'div_user_vip'
 NOR_ID = 'div_user_nor'
 LV1_ID = 'div_user_lv1'
 
+PATTERN_USER_RESET = r'Lv\d+\s*額度\s*:\s*每月\s*(\d+)\s*日'
+PATTERN_USER_TOTAL = r'Lv\d+\s*每月額度\s*:\s*([\d.]+)\s*M'
+PATTERN_USER_USED = r'本月已用免費額度\s*:\s*([\d.]+)\s*M'
+
+PATTERN_VIP_RESET = r'VIP\s*額度\s*:\s*每月\s*(\d+)\s*日'
+PATTERN_VIP_TOTAL = r'VIP\s*每月額度\s*:\s*([\d.]+)\s*M'
+PATTERN_VIP_USED = r'本月已經用VIP額度\s*:\s*([\d.]+)\s*M'
+
 @async_retry()
 async def check_status(
         session: ClientSession,
         console: Console,
+        username: str,
+        cookies: dict[str, str],
         show_quota: bool = False,
-        is_vip_setter: Optional[Callable[[int], None]] = None,
-        level_setter: Optional[Callable[[int], None]] = None,
-) -> bool:
-    async with session.get(url = API_ROUTE.PROFILE) as response:
-        try:
-            response.raise_for_status()
-        except Exception as e:
-            info(f"Error: {type(e).__name__}: {e}")
-            return False
+) -> Credential:
+    async with session.get(url = API_ROUTE.PROFILE, cookies=cookies) as response:
+        response.raise_for_status()
         
         if response.history and any(resp.status in (301, 302, 307) for resp in response.history) \
                 and URL(response.url).path == API_ROUTE.LOGIN:
             raise LoginError("凭证已失效，请重新登录。", ['kmdr config -c cookie', 'kmdr login -u <username>'])
-
-        if not is_vip_setter and not level_setter and not show_quota:
-            return True
         
-        from bs4 import BeautifulSoup
+        cookies = extract_cookies(response)
 
         # 如果后续有性能问题，可以先考虑使用 lxml 进行解析
         soup = BeautifulSoup(await response.text(), 'html.parser')
@@ -53,23 +56,29 @@ async def check_status(
 
             debug("解析到用户状态: is_vip=", is_vip, ", user_level=", user_level)
 
-            if is_vip_setter:
-                is_vip_setter(is_vip)
-            if level_setter:
-                level_setter(user_level)
-        
-        if not show_quota:
-            return True
-
-        nickname = soup.find('div', id=NICKNAME_ID).text.strip().split(' ')[0].replace('\xa0', '')
-        quota = soup.find('div', id=__resolve_quota_id(is_vip, user_level)).text.strip().replace('\xa0', '')
-
-        if console.is_interactive:
-            info(f"\n当前登录为 [bold cyan]{nickname}[/bold cyan]\n\n{quota}")
         else:
-            info(f"当前登录为 {nickname}")
+            is_vip = None
+            user_level = None
+        
+        nickname = soup.find('div', id=NICKNAME_ID).text.strip().split(' ')[0].replace('\xa0', '')
+        raw_quota = soup.find('div', id=__resolve_quota_id(is_vip, user_level)).text.strip().replace('\xa0', '')
 
-        return True
+        if show_quota:
+            if console.is_interactive:
+                info(f"\n当前登录为 [bold cyan]{nickname}[/bold cyan]\n\n{raw_quota}")
+            else:
+                info(f"当前登录为 {nickname}")
+
+        user_quota, vip_quota = extract_quota(soup)
+        
+        return Credential(
+            username=username,
+            nickname=nickname,
+            cookies=cookies,
+            user_quota=user_quota,
+            vip_quota=vip_quota,
+            level=user_level or 0,
+        )
 
 def extract_var_define(script_text) -> dict[str, str]:
     var_define = {}
@@ -82,6 +91,46 @@ def extract_var_define(script_text) -> dict[str, str]:
                 var_define[var_name.strip()] = var_value
     debug("解析到变量定义: ", var_define)
     return var_define
+
+def extract_quota(soup: BeautifulSoup) -> tuple[QuotaInfo, Union[QuotaInfo, None]]:
+    is_vip = False
+    vip_div = soup.find('div', id=VIP_ID)
+    
+    if isinstance(vip_div, Tag):
+        style = vip_div.get('style', '')
+        if isinstance(style, list):
+            style = ' '.join(style)
+
+        style_str = style.lower().replace(' ', '') if style else ''
+
+        if 'display:none' not in style_str:
+            is_vip = True
+            
+    raw_text = soup.get_text(separator=' ', strip=True)
+
+    user_quota = QuotaInfo(
+        reset_day=_extract_int(PATTERN_USER_RESET, raw_text, default=1),
+        total=_extract_float(PATTERN_USER_TOTAL, raw_text, default=0.0),
+        used=_extract_float(PATTERN_USER_USED, raw_text, default=0.0)
+    )
+
+    vip_quota = None
+    if is_vip:
+        vip_quota = QuotaInfo(
+            reset_day=_extract_int(PATTERN_VIP_RESET, raw_text, default=1),
+            total=_extract_float(PATTERN_VIP_TOTAL, raw_text, default=0.0),
+            used=_extract_float(PATTERN_VIP_USED, raw_text, default=0.0)
+        )
+
+    return user_quota, vip_quota
+
+def _extract_int(pattern: str, text: str, default: int = 0) -> int:
+    match = re.search(pattern, text)
+    return int(match.group(1)) if match else default
+
+def _extract_float(pattern: str, text: str, default: float = 0.0) -> float:
+    match = re.search(pattern, text)
+    return float(match.group(1)) if match else default
 
 def __resolve_quota_id(is_vip: Optional[int] = None, user_level: Optional[int] = None):
     if is_vip is not None and is_vip >= 1:

--- a/src/kmdr/module/authenticator/utils.py
+++ b/src/kmdr/module/authenticator/utils.py
@@ -41,7 +41,7 @@ async def check_status(
                 and URL(response.url).path == API_ROUTE.LOGIN:
             raise LoginError("凭证已失效，请重新登录。", ['kmdr config -c cookie', 'kmdr login -u <username>'])
         
-        cookies = extract_cookies(response)
+        cookies = {**cookies, **extract_cookies(response)}
 
         # 如果后续有性能问题，可以先考虑使用 lxml 进行解析
         soup = BeautifulSoup(await response.text(), 'html.parser')

--- a/src/kmdr/module/configurer/__init__.py
+++ b/src/kmdr/module/configurer/__init__.py
@@ -3,3 +3,11 @@ from .ConfigClearer import ConfigClearer
 from .OptionLister import OptionLister
 from .OptionSetter import OptionSetter
 from .ConfigUnsetter import ConfigUnsetter
+
+__all__ = [
+    "BaseUrlUpdator",
+    "ConfigClearer",
+    "OptionLister",
+    "OptionSetter",
+    "ConfigUnsetter",
+]

--- a/src/kmdr/module/downloader/DirectDownloader.py
+++ b/src/kmdr/module/downloader/DirectDownloader.py
@@ -2,6 +2,7 @@ from functools import partial
 
 from kmdr.core import Downloader, BookInfo, VolInfo, DOWNLOADER
 from kmdr.core.constants import API_ROUTE
+from kmdr.core.structure import Credential
 
 from .download_utils import download_file_multipart, readable_safe_filename, download_file
 
@@ -16,7 +17,7 @@ class DirectDownloader(Downloader):
         self._use_vip = vip
         self._disable_multi_part = disable_multi_part
 
-    async def _download(self, book: BookInfo, volume: VolInfo):
+    async def _download(self, cred: Credential, book: BookInfo, volume: VolInfo):
         sub_dir = readable_safe_filename(book.name)
         download_path = f'{self._dest}/{sub_dir}'
 
@@ -25,10 +26,11 @@ class DirectDownloader(Downloader):
                 self._session,
                 self._semaphore,
                 self._progress,
-                partial(self.construct_download_url, book, volume),
+                partial(self.construct_download_url, cred, book, volume),
                 download_path,
                 readable_safe_filename(f'[Kmoe][{book.name}][{volume.name}].epub'),
                 self._retry,
+                cookies=cred.cookies,
                 callback=lambda: self._callback(book, volume) if self._callback else None
             )
             return
@@ -37,16 +39,17 @@ class DirectDownloader(Downloader):
             self._session,
             self._semaphore,
             self._progress,
-            partial(self.construct_download_url, book, volume),
+            partial(self.construct_download_url, cred, book, volume),
             download_path,
             readable_safe_filename(f'[Kmoe][{book.name}][{volume.name}].epub'),
             self._retry,
+            cookies=cred.cookies,
             callback=lambda: self._callback(book, volume) if self._callback else None
         )
 
-    def construct_download_url(self, book: BookInfo, volume: VolInfo) -> str:
+    def construct_download_url(self, cred: Credential, book: BookInfo, volume: VolInfo) -> str:
         return API_ROUTE.DOWNLOAD.format(
             book_id=book.id,
             volume_id=volume.id,
-            is_vip=self._profile.is_vip if self._use_vip else 0
+            is_vip=cred.is_vip if self._use_vip else 0
         )

--- a/src/kmdr/module/downloader/DirectDownloader.py
+++ b/src/kmdr/module/downloader/DirectDownloader.py
@@ -51,5 +51,5 @@ class DirectDownloader(Downloader):
         return API_ROUTE.DOWNLOAD.format(
             book_id=book.id,
             volume_id=volume.id,
-            is_vip=cred.is_vip if self._use_vip else 0
+            is_vip=1 if self._use_vip and cred.is_vip else 0
         )

--- a/src/kmdr/module/downloader/ReferViaDownloader.py
+++ b/src/kmdr/module/downloader/ReferViaDownloader.py
@@ -29,7 +29,7 @@ class ReferViaDownloader(Downloader):
         sub_dir = readable_safe_filename(book.name)
         download_path = f'{self._dest}/{sub_dir}'
 
-        if self._disable_multi_part or (cred.is_vip == 0 and not self._try_multi_part):
+        if self._disable_multi_part or (not cred.is_vip and not self._try_multi_part):
             # 2025/11: 服务器对于普通用户似乎不支持分片下载
             # 所以这里对普通用户默认使用完整下载，如果想要尝试分片下载，可以使用 --try-multi-part 参数
             # 参考 issue: https://github.com/chrisis58/kmoe-manga-downloader/issues/28
@@ -43,7 +43,7 @@ class ReferViaDownloader(Downloader):
                 self._retry,
                 headers=DOWNLOAD_HEAD,
                 callback=lambda: self._callback(book, volume) if self._callback else None,
-                resumable=cred.is_vip == 1, # 仅 VIP 用户支持断点续传
+                resumable=cred.is_vip, # 仅 VIP 用户支持断点续传
             )
             return
 

--- a/src/kmdr/module/downloader/__init__.py
+++ b/src/kmdr/module/downloader/__init__.py
@@ -1,2 +1,7 @@
 from .DirectDownloader import DirectDownloader
 from .ReferViaDownloader import ReferViaDownloader
+
+__all__ = [
+    "DirectDownloader",
+    "ReferViaDownloader",
+]

--- a/src/kmdr/module/lister/__init__.py
+++ b/src/kmdr/module/lister/__init__.py
@@ -1,2 +1,7 @@
 from .BookUrlLister import BookUrlLister
 from .FollowedBookLister import FollowedBookLister
+
+__all__ = [
+    "BookUrlLister",
+    "FollowedBookLister",
+]

--- a/src/kmdr/module/picker/__init__.py
+++ b/src/kmdr/module/picker/__init__.py
@@ -1,2 +1,7 @@
 from .ArgsFilterPicker import ArgsFilterPicker
 from .DefaultVolPicker import DefaultVolPicker
+
+__all__ = [
+    "ArgsFilterPicker",
+    "DefaultVolPicker",
+]

--- a/src/kmdr/module/pool/PoolCredRemover.py
+++ b/src/kmdr/module/pool/PoolCredRemover.py
@@ -1,0 +1,18 @@
+from kmdr.core.bases import PoolManager, POOL_MANAGER
+from kmdr.core.console import info
+
+@POOL_MANAGER.register(
+    hasvalues={'pool_command': 'remove'}
+)
+class PoolCredRemover(PoolManager):
+    
+    def __init__(self, username: str, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self._username = username
+
+    async def operate(self) -> None:
+        ret = self._pool.remove(self._username)
+        if not ret:
+            info(f"凭证池中不存在用户 '{self._username}' 。")
+        else:
+            info(f"已从凭证池中移除用户 '{self._username}' 。")

--- a/src/kmdr/module/pool/PoolCredSwitcher.py
+++ b/src/kmdr/module/pool/PoolCredSwitcher.py
@@ -18,5 +18,9 @@ class PoolCredSwitcher(PoolManager):
             info(f"凭证池中不存在用户 '{self._username}' 。")
             return
 
-        self._configurer.cookie = cred.cookies
+        try:
+            self._configurer.cookie = cred.cookies
+        except Exception as e:
+            info(f"[red]设置默认账号失败: {e}[/red]")
+            return
         info(f"已将用户 '{self._username}' 应用为当前默认账号。")

--- a/src/kmdr/module/pool/PoolCredSwitcher.py
+++ b/src/kmdr/module/pool/PoolCredSwitcher.py
@@ -1,0 +1,22 @@
+from kmdr.core.bases import PoolManager, POOL_MANAGER
+from kmdr.core.console import info
+
+@POOL_MANAGER.register(
+    hasvalues={'pool_command': 'use'}
+)
+class PoolCredSwitcher(PoolManager):
+    
+    def __init__(self, username: str, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self._username = username
+
+    async def operate(self) -> None:
+
+        cred = self._pool.find(self._username)
+
+        if not cred:
+            info(f"凭证池中不存在用户 '{self._username}' 。")
+            return
+
+        self._configurer.cookie = cred.cookies
+        info(f"已将用户 '{self._username}' 应用为当前默认账号。")

--- a/src/kmdr/module/pool/PoolCredUpdator.py
+++ b/src/kmdr/module/pool/PoolCredUpdator.py
@@ -1,0 +1,31 @@
+from typing import Optional
+
+from kmdr.core.bases import PoolManager, POOL_MANAGER
+from kmdr.core.console import info
+
+@POOL_MANAGER.register(
+    hasvalues={'pool_command': 'update'}
+)
+class PoolCredUpdator(PoolManager):
+    
+    def __init__(self, username: str, note: Optional[str] = None, order: Optional[int] = None, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self._username = username
+        self._note = note
+        self._order = order
+    
+    async def operate(self) -> None:
+        cred = self._pool.find(self._username)
+
+        if not cred:
+            info(f"凭证池中不存在用户 '{self._username}' 。")
+            return
+
+        if self._note is not None:
+            cred.note = self._note
+        
+        if self._order is not None:
+            cred.order = self._order
+
+        self._configurer.update()
+        info(f"已更新用户 '{self._username}' 的信息。")

--- a/src/kmdr/module/pool/PoolInsertionHandler.py
+++ b/src/kmdr/module/pool/PoolInsertionHandler.py
@@ -22,7 +22,7 @@ class PoolInsertionHandler(PoolManager):
     async def operate(self) -> None:
 
         if self._pool.check_duplicate(self._username):
-            info(f"用户 '{self._username}' 已存在于凭证池中，添加操作已取消。")
+            info(f"用户 '{self._username}' 已存在于凭证池中。")
             return
         
         async with (await KmdrSessionManager().session()):

--- a/src/kmdr/module/pool/PoolInsertionHandler.py
+++ b/src/kmdr/module/pool/PoolInsertionHandler.py
@@ -12,10 +12,12 @@ from kmdr.module.authenticator.LoginAuthenticator import LoginAuthenticator
 )
 class PoolInsertionHandler(PoolManager):
 
-    def __init__(self, username: str, password: Optional[str] = None, *args, **kwargs):
+    def __init__(self, username: str, password: Optional[str] = None, order: Optional[int] = None, note: Optional[str] = None, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self._username = username
         self._password = password
+        self._order = order
+        self._note = note
 
     async def operate(self) -> None:
 
@@ -30,6 +32,12 @@ class PoolInsertionHandler(PoolManager):
                 show_quota=False,
             )
             cred = await authenticator.authenticate()
+
+            if self._order is not None:
+                cred.order = self._order
+            if self._note is not None:
+                cred.note = self._note
+
             self._pool.add(cred)
 
             info(f"已将用户 '{self._username}' 添加到凭证池中。")

--- a/src/kmdr/module/pool/PoolInsertionHandler.py
+++ b/src/kmdr/module/pool/PoolInsertionHandler.py
@@ -2,6 +2,7 @@ from typing import Optional
 
 from kmdr.core.bases import PoolManager, POOL_MANAGER
 from kmdr.core.session import KmdrSessionManager
+from kmdr.core.console import info
 
 from kmdr.module.authenticator.LoginAuthenticator import LoginAuthenticator
 
@@ -26,3 +27,5 @@ class PoolInsertionHandler(PoolManager):
             )
             cred = await authenticator.authenticate()
             self._pool.add(cred)
+
+            info(f"已将用户 '{self._username}' 添加到凭证池中。")

--- a/src/kmdr/module/pool/PoolInsertionHandler.py
+++ b/src/kmdr/module/pool/PoolInsertionHandler.py
@@ -1,0 +1,28 @@
+from typing import Optional
+
+from kmdr.core.bases import PoolManager, POOL_MANAGER
+from kmdr.core.session import KmdrSessionManager
+
+from kmdr.module.authenticator.LoginAuthenticator import LoginAuthenticator
+
+
+@POOL_MANAGER.register(
+    hasvalues={'pool_command': 'add'}
+)
+class PoolInsertionHandler(PoolManager):
+
+    def __init__(self, username: str, password: Optional[str] = None, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self._username = username
+        self._password = password
+
+    async def operate(self) -> None:
+        
+        async with (await KmdrSessionManager().session()):
+            authenticator = LoginAuthenticator(
+                username=self._username,
+                password=self._password,
+                show_quota=False,
+            )
+            cred = await authenticator.authenticate()
+            self._pool.add(cred)

--- a/src/kmdr/module/pool/PoolInsertionHandler.py
+++ b/src/kmdr/module/pool/PoolInsertionHandler.py
@@ -18,6 +18,10 @@ class PoolInsertionHandler(PoolManager):
         self._password = password
 
     async def operate(self) -> None:
+
+        if self._pool.check_duplicate(self._username):
+            info(f"用户 '{self._username}' 已存在于凭证池中，添加操作已取消。")
+            return
         
         async with (await KmdrSessionManager().session()):
             authenticator = LoginAuthenticator(

--- a/src/kmdr/module/pool/PoolLister.py
+++ b/src/kmdr/module/pool/PoolLister.py
@@ -146,6 +146,8 @@ class PoolLister(PoolManager):
                     show_quota=False 
                 )
 
+                # rich.Live 有可能会读到部分更新的数据
+                # 但是不会影响最终结果，所以这里不加锁
                 cred.user_quota = new_cred.user_quota
                 cred.vip_quota = new_cred.vip_quota
                 cred.status = new_cred.status

--- a/src/kmdr/module/pool/PoolLister.py
+++ b/src/kmdr/module/pool/PoolLister.py
@@ -1,5 +1,6 @@
 import asyncio
 from datetime import datetime
+import random
 from typing import Set
 
 from rich.live import Live
@@ -133,6 +134,9 @@ class PoolLister(PoolManager):
 
     async def _check_and_update_single(self, session, cred: Credential, semaphore: asyncio.Semaphore):
         async with semaphore:
+            # 防止瞬时并发过高
+            await asyncio.sleep(random.uniform(0, 0.3))
+
             try:
                 new_cred = await check_status(
                     session=session,

--- a/src/kmdr/module/pool/PoolLister.py
+++ b/src/kmdr/module/pool/PoolLister.py
@@ -1,0 +1,159 @@
+import asyncio
+from datetime import datetime
+from typing import Set
+
+from rich.live import Live
+from rich.table import Table
+from rich.spinner import Spinner
+from rich import box
+
+from kmdr.core.bases import PoolManager, POOL_MANAGER
+from kmdr.core.session import KmdrSessionManager
+from kmdr.core.structure import CredentialStatus, Credential
+from kmdr.core.console import debug, info
+
+from kmdr.module.authenticator.utils import check_status
+
+@POOL_MANAGER.register(
+    hasvalues={'pool_command': 'list'}
+)
+class PoolLister(PoolManager):
+    
+    def __init__(self, refresh: bool = False, num_workers: int = 3, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.__refresh = refresh
+        self.__num_workers = num_workers
+        self._updating_users: Set[str] = set()
+
+    
+    async def operate(self) -> None:
+        credentials = self._pool.pool
+
+        if not credentials:
+            info("凭证池为空, 请先使用 'kmdr pool add' 命令添加凭证。")
+            return
+
+        if not self.__refresh:
+            self._console.print(self._generate_table())
+            info("剩余可用额度: ", str(sum(c.quota_remaining for c in credentials if c.status == CredentialStatus.ACTIVE)), " MB")
+            return
+
+        # 耗时操作，刷新所有凭证状态
+        async with (await KmdrSessionManager().session()) as session:
+
+            self._updating_users = {c.username for c in credentials}
+            
+            semaphore = asyncio.Semaphore(self.__num_workers)
+
+            with Live(self._generate_table(), console=self._console, refresh_per_second=12) as live:
+                
+                tasks = [
+                    self._check_and_update_single(session, cred, semaphore) 
+                    for cred in credentials
+                ]
+                
+                for future in asyncio.as_completed(tasks):
+                    updated_cred = await future
+                    self._updating_users.remove(updated_cred.username)
+                    live.update(self._generate_table())
+
+        info("剩余可用额度: ", str(sum(c.quota_remaining for c in credentials if c.status == CredentialStatus.ACTIVE)), " MB")
+        try:
+            self._configurer.update()
+            debug("[green]已更新", len(credentials), "个凭证。[/green]")
+        except Exception as e:
+            info(f"[red]保存配置文件失败: {e}[/red]")
+
+
+    def _format_time(self, timestamp: float) -> str:
+        if not timestamp:
+            return "-"
+        dt = datetime.fromtimestamp(timestamp)
+        return dt.strftime("%Y-%m-%d %H:%M")
+
+    def _format_status(self, status: CredentialStatus) -> str:
+        if status == CredentialStatus.ACTIVE:
+            return "[bold green]ACTIVE[/bold green]"
+        elif status == CredentialStatus.INVALID:
+            return "[bold red]INVALID[/bold red]"
+        elif status == CredentialStatus.QUOTA_EXCEEDED:
+            return "[yellow]EXCEEDED[/yellow]"
+        elif status == CredentialStatus.DISABLED:
+            return "[dim white]DISABLED[/dim white]"
+        else:
+            return f"[cyan]{status.name}[/cyan]"
+
+    def _generate_table(self) -> Table:
+        credentials = self._pool.pool
+        
+        table = Table(
+            title="凭证池状态",
+            box=box.ROUNDED,
+            header_style="bold blue",
+            expand=True
+        )
+
+        table.add_column("Order", justify="right", style="dim", width=6)
+        table.add_column("用户名", style="magenta")
+        table.add_column("昵称", style="green")
+        table.add_column("剩余额度", justify="right")
+        table.add_column("状态", justify="center")
+        table.add_column("最后更新", style="dim", width=22) 
+        table.add_column("备注", style="dim italic")
+
+        if not credentials:
+            return table
+
+        sorted_creds = sorted(credentials, key=lambda x: x.order)
+
+        for cred in sorted_creds:
+            time_str = self._format_time(cred.user_quota.update_at)
+            
+            if cred.username in self._updating_users:
+                status_renderable = Spinner("dots", text="更新中...", style="yellow")
+                last_update_renderable = Spinner("dots", text=f" {time_str}", style="yellow")
+                quota_str = Spinner("dots", text=f"{cred.quota_remaining:.1f} MB", style="yellow")
+            else:
+                status_renderable = self._format_status(cred.status)
+                last_update_renderable = time_str
+                quota_str = f"{cred.quota_remaining:.1f} MB"
+            
+
+            table.add_row(
+                str(cred.order),
+                cred.username,
+                cred.nickname or "-",
+                quota_str,
+                status_renderable,
+                last_update_renderable,
+                cred.note or "-"
+            )
+        
+        return table
+
+    async def _check_and_update_single(self, session, cred: Credential, semaphore: asyncio.Semaphore):
+        async with semaphore:
+            try:
+                new_cred = await check_status(
+                    session=session,
+                    console=self._console,
+                    username=cred.username,
+                    cookies=cred.cookies,
+                    show_quota=False 
+                )
+
+                cred.user_quota = new_cred.user_quota
+                cred.vip_quota = new_cred.vip_quota
+                cred.status = new_cred.status
+                cred.level = new_cred.level
+                cred.nickname = new_cred.nickname
+                cred.cookies = new_cred.cookies
+
+                await asyncio.sleep(10)
+
+                return cred
+
+            except Exception as e:
+                cred.status = CredentialStatus.INVALID
+                info(f"[red]更新用户 {cred.username} 失败[/red]")
+                return cred

--- a/src/kmdr/module/pool/PoolLister.py
+++ b/src/kmdr/module/pool/PoolLister.py
@@ -36,7 +36,7 @@ class PoolLister(PoolManager):
 
         if not self.__refresh:
             self._console.print(self._generate_table())
-            info("剩余可用额度: ", str(sum(c.quota_remaining for c in credentials if c.status == CredentialStatus.ACTIVE)), " MB")
+            info("剩余可用总额度: ", str(sum(c.quota_remaining for c in credentials if c.status == CredentialStatus.ACTIVE)), " MB")
             return
 
         # 耗时操作，刷新所有凭证状态
@@ -58,7 +58,7 @@ class PoolLister(PoolManager):
                     self._updating_users.remove(updated_cred.username)
                     live.update(self._generate_table())
 
-        info("剩余可用额度: ", str(sum(c.quota_remaining for c in credentials if c.status == CredentialStatus.ACTIVE)), " MB")
+        info("剩余可用总额度: ", str(sum(c.quota_remaining for c in credentials if c.status == CredentialStatus.ACTIVE)), " MB")
         try:
             self._configurer.update()
             debug("[green]已更新", len(credentials), "个凭证。[/green]")
@@ -94,13 +94,13 @@ class PoolLister(PoolManager):
             expand=True
         )
 
-        table.add_column("Order", justify="right", style="dim", width=6)
-        table.add_column("用户名", style="magenta")
-        table.add_column("昵称", style="green")
-        table.add_column("剩余额度", justify="right")
+        table.add_column("Order", justify="center", style="dim", width=6)
+        table.add_column("用户名", justify="center", style="magenta")
+        table.add_column("昵称", justify="center", style="green")
+        table.add_column("剩余额度", justify="center")
         table.add_column("状态", justify="center")
-        table.add_column("最后更新", style="dim", width=22) 
-        table.add_column("备注", style="dim italic")
+        table.add_column("最后更新", justify="center", style="dim", width=22) 
+        table.add_column("备注", justify="center", style="dim italic")
 
         if not credentials:
             return table

--- a/src/kmdr/module/pool/PoolLister.py
+++ b/src/kmdr/module/pool/PoolLister.py
@@ -149,8 +149,6 @@ class PoolLister(PoolManager):
                 cred.nickname = new_cred.nickname
                 cred.cookies = new_cred.cookies
 
-                await asyncio.sleep(10)
-
                 return cred
 
             except Exception as e:

--- a/src/kmdr/module/pool/PoolLister.py
+++ b/src/kmdr/module/pool/PoolLister.py
@@ -160,4 +160,5 @@ class PoolLister(PoolManager):
             except Exception as e:
                 cred.status = CredentialStatus.INVALID
                 info(f"[red]更新用户 {cred.username} 失败[/red]")
+                debug(f"更新用户 {cred.username} 失败: {e}")
                 return cred

--- a/src/kmdr/module/pool/__init__.py
+++ b/src/kmdr/module/pool/__init__.py
@@ -3,3 +3,11 @@ from .PoolLister import PoolLister
 from .PoolCredRemover import PoolCredRemover
 from .PoolCredSwitcher import PoolCredSwitcher
 from .PoolCredUpdator import PoolCredUpdator
+
+__all__ = [
+    "PoolInsertionHandler",
+    "PoolLister",
+    "PoolCredRemover",
+    "PoolCredSwitcher",
+    "PoolCredUpdator",
+]

--- a/src/kmdr/module/pool/__init__.py
+++ b/src/kmdr/module/pool/__init__.py
@@ -1,1 +1,2 @@
 from .PoolInsertionHandler import PoolInsertionHandler
+from .PoolLister import PoolLister

--- a/src/kmdr/module/pool/__init__.py
+++ b/src/kmdr/module/pool/__init__.py
@@ -1,3 +1,4 @@
 from .PoolInsertionHandler import PoolInsertionHandler
 from .PoolLister import PoolLister
 from .PoolCredRemover import PoolCredRemover
+from .PoolCredSwitcher import PoolCredSwitcher

--- a/src/kmdr/module/pool/__init__.py
+++ b/src/kmdr/module/pool/__init__.py
@@ -1,0 +1,1 @@
+from .PoolInsertionHandler import PoolInsertionHandler

--- a/src/kmdr/module/pool/__init__.py
+++ b/src/kmdr/module/pool/__init__.py
@@ -2,3 +2,4 @@ from .PoolInsertionHandler import PoolInsertionHandler
 from .PoolLister import PoolLister
 from .PoolCredRemover import PoolCredRemover
 from .PoolCredSwitcher import PoolCredSwitcher
+from .PoolCredUpdator import PoolCredUpdator

--- a/src/kmdr/module/pool/__init__.py
+++ b/src/kmdr/module/pool/__init__.py
@@ -1,2 +1,3 @@
 from .PoolInsertionHandler import PoolInsertionHandler
 from .PoolLister import PoolLister
+from .PoolCredRemover import PoolCredRemover

--- a/tests/test_cred_pool.py
+++ b/tests/test_cred_pool.py
@@ -1,0 +1,192 @@
+import unittest
+import time
+from unittest.mock import MagicMock
+
+from kmdr.core.pool import CredentialPool, PooledCredential
+from kmdr.core.structure import Credential, CredentialStatus, QuotaInfo, Config
+
+def create_quota(total=100.0, used=10.0):
+    return QuotaInfo(total=total, used=used, reset_day=1, update_at=time.time())
+
+def create_cred(username="user1", order=0, status=CredentialStatus.ACTIVE, is_vip=False):
+    vip_quota = create_quota(500.0, 0.0) if is_vip else None
+    return Credential(
+        username=username,
+        cookies={"token": "abc"},
+        user_quota=create_quota(),
+        vip_quota=vip_quota,
+        level=1,
+        order=order,
+        status=status,
+        nickname=f"Nick-{username}"
+    )
+
+class TestCredentialPool(unittest.TestCase):
+
+    def setUp(self):
+        self.mock_configurer = MagicMock()
+        self.mock_config = Config()
+        self.mock_config.cred_pool = []
+        self.mock_configurer.config = self.mock_config
+        
+        self.pool_mgr = CredentialPool(self.mock_configurer)
+
+    def test_add_and_check_duplicate(self):
+        """添加凭证后应能在列表中找到，并且排重逻辑生效"""
+        cred = create_cred("user_new")
+        self.pool_mgr.add(cred)
+
+        # 验证加入列表
+        assert self.mock_config.cred_pool is not None
+        self.assertIn(cred, self.mock_config.cred_pool)
+        # 验证调用了 save
+        self.mock_configurer.update.assert_called()
+        # 验证排重逻辑
+        self.assertTrue(self.pool_mgr.check_duplicate("user_new"))
+        self.assertFalse(self.pool_mgr.check_duplicate("user_not_exist"))
+
+    def test_remove(self):
+        """删除凭证后不应在列表中"""
+        cred = create_cred("user_rem")
+        self.pool_mgr.add(cred)
+        
+        result = self.pool_mgr.remove("user_rem")
+        
+        self.assertTrue(result)
+        assert self.mock_config.cred_pool is not None
+        self.assertEqual(len(self.mock_config.cred_pool), 0)
+        self.mock_configurer.update.assert_called()
+
+    def test_update_status(self):
+        """更新凭证状态后应反映在对象中"""
+        cred = create_cred("user_stat", status=CredentialStatus.ACTIVE)
+        self.pool_mgr.add(cred)
+
+        self.pool_mgr.update_status("user_stat", CredentialStatus.DISABLED)
+        
+        self.assertEqual(cred.status, CredentialStatus.DISABLED)
+        self.mock_configurer.update.assert_called()
+
+    def test_active_creds_property_sorts_by_order(self):
+        """active_creds 属性应返回活跃用户并按优先级排序"""
+        c1 = create_cred("u1", order=10, status=CredentialStatus.ACTIVE)
+        c2 = create_cred("u2", order=1, status=CredentialStatus.ACTIVE)
+        c3 = create_cred("u3", order=5, status=CredentialStatus.DISABLED) # 不应出现
+
+        self.mock_config.cred_pool = [c1, c2, c3]
+        
+        active_list = self.pool_mgr.active_creds
+        
+        self.assertEqual(len(active_list), 2)
+        # 顺序应该是 u2(1) -> u1(10)
+        self.assertEqual(active_list[0].username, "u2")
+        self.assertEqual(active_list[1].username, "u1")
+
+    def test_get_next_cycle_logic(self):
+        """get_next 方法应按顺序轮询返回凭证"""
+        c1 = create_cred("A", order=1)
+        c2 = create_cred("B", order=2)
+        self.mock_config.cred_pool = [c1, c2]
+
+        # 第一次获取，应该是 A (order 1)
+        n1 = self.pool_mgr.get_next()
+        assert n1 is not None
+        self.assertEqual(n1.username, "A")
+
+        # 第二次获取，应该是 B (order 2)
+        n2 = self.pool_mgr.get_next()
+        assert n2 is not None
+        self.assertEqual(n2.username, "B")
+
+        # 第三次获取，应该回到 A (Cycle)
+        n3 = self.pool_mgr.get_next()
+        assert n3 is not None
+        self.assertEqual(n3.username, "A")
+
+    def test_get_next_skips_invalid(self):
+        """get_next 应自动跳过状态变成非 ACTIVE 的凭证"""
+        c1 = create_cred("A", status=CredentialStatus.ACTIVE)
+        c2 = create_cred("B", status=CredentialStatus.ACTIVE)
+        self.mock_config.cred_pool = [c1, c2]
+
+        # 初始化迭代器
+        cred = self.pool_mgr.get_next()
+        assert cred is not None
+        self.assertEqual(cred.username, "A")
+
+        # 把 B 禁用
+        c2.status = CredentialStatus.DISABLED
+
+        # 下一次获取应该跳过 B，直接再次返回 A
+        n = self.pool_mgr.get_next()
+        assert n is not None
+        self.assertEqual(n.username, "A")
+
+    def test_get_next_returns_none_if_empty(self):
+        self.mock_config.cred_pool = []
+        self.assertIsNone(self.pool_mgr.get_next())
+
+class TestPooledCredential(unittest.TestCase):
+
+    def setUp(self):
+        # User配额 100/10，VIP配额 500/0
+        self.base_cred = create_cred("pool_user", is_vip=True)
+        self.pooled = PooledCredential(self.base_cred)
+
+    def test_init_clears_reserved(self):
+        """初始化时应重置 reserved 字段"""
+        self.base_cred.user_quota.reserved = 50.0
+        p = PooledCredential(self.base_cred)
+        self.assertEqual(p.inner.user_quota.reserved, 0.0)
+
+    def test_reserve_success(self):
+        """预留流量成功时应更新 reserved 字段"""
+        # 剩余 90 (100-10)
+        # 尝试预留 50 -> 成功
+        success = self.pooled.reserve(50.0, is_vip=False)
+        self.assertTrue(success)
+        self.assertEqual(self.base_cred.user_quota.reserved, 50.0)
+
+    def test_reserve_fail_insufficient(self):
+        """预留流量失败时 reserved 字段不应改变"""
+        # 剩余 90
+        # 尝试预留 91 -> 失败
+        success = self.pooled.reserve(91.0, is_vip=False)
+        self.assertFalse(success)
+        self.assertEqual(self.base_cred.user_quota.reserved, 0.0)
+
+    def test_commit(self):
+        """提交预留流量后应更新 unsynced_usage 和 reserved"""
+        # 预留 20
+        self.pooled.reserve(20.0, is_vip=False)
+        # 提交 20
+        self.pooled.commit(20.0, is_vip=False)
+
+        self.assertEqual(self.base_cred.user_quota.reserved, 0.0)
+        self.assertEqual(self.base_cred.user_quota.unsynced_usage, 20.0)
+        
+    def test_rollback(self):
+        """回滚预留流量后应更新 reserved 字段"""
+        # 预留 20
+        self.pooled.reserve(20.0, is_vip=False)
+        # 回滚 20
+        self.pooled.rollback(20.0, is_vip=False)
+
+        self.assertEqual(self.base_cred.user_quota.reserved, 0.0)
+        self.assertEqual(self.base_cred.user_quota.unsynced_usage, 0.0)
+
+    def test_update_from_server(self):
+        """从服务端更新凭证信息应覆盖本地数据"""
+        # 本地有 unsynced 数据
+        self.base_cred.user_quota.unsynced_usage = 50.0
+        
+        # 服务端发来新数据
+        server_cred = create_cred("pool_user", is_vip=True)
+        server_cred.user_quota.total = 200.0
+        server_cred.user_quota.used = 59.0
+        
+        self.pooled.update_from_server(server_cred)
+        
+        self.assertEqual(self.base_cred.user_quota.total, 200.0)
+        self.assertEqual(self.base_cred.user_quota.unsynced_usage, 0.0)
+        self.assertEqual(self.base_cred.user_quota.used, 59.0)


### PR DESCRIPTION
本此更新引入了全新的 **凭证池 (Credential Pool)** 管理模块，允许用户在本地存储和管理多个账号凭证。通过新的 `pool` 子命令，用户可以方便地添加、移除、更新账号，查看账号配额状态，并在不同账号间快速切换。

#### 新增功能

新增 `pool` 子命令，支持以下操作：

- **`add` (添加账号)**
  - 支持录入用户名、密码。
  - 支持设置账号优先级 (`order`)，用于后续的自动化调度。
  - 支持添加备注信息 (`note`)。
  - 用法：`kmdr pool add -u <username> [-p <password>] [-o 0] [-n "备注"]`
- **`list` (查看列表)**
  - 使用表格展示所有已保存账号的详细信息。
  - **支持并发刷新**：通过 `--refresh` 参数实时检查所有账号的有效性和配额。
  - 支持自定义并发数：`--num-workers` (默认 3) 以避免触发服务端频控。
  - UI 优化：集成 `rich.live` 和 `Spinner` 显示刷新进度。
  - 用法：`kmdr pool list [-r] [--num-workers 3]`
- **`use` (切换账号)**
  - 将指定账号设置为当前的全局默认账号。
  - 用法：`kmdr pool use <username>`
- **`update` (更新信息)**
  - 支持修改已存在账号的备注和优先级。
  - 用法：`kmdr pool update <username> [-n "新备注"] [-o 10]`
- **`remove` (移除账号)**
  - 从池中彻底删除指定账号。
  - 用法：`kmdr pool remove <username>`

#### 功能重构

重构原有的串行逻辑，修改为 `fork-join` 并发模型以优化执行效率，并为后续动态切换用户凭证做准备。

#### 相关 Issue

#33 