### PR TITLE
feat: 添加书籍格式的选择

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,7 @@ kmdr download -d path/to/destination -l https://kxx.moe/c/50076.htm -t extra -v 
 - `-l`, `--book-url`: 指定漫画的主页地址
 - `-v`, `--volume`: 指定下载的卷，多个用逗号分隔，例如 `1,2,3` 或 `1-5,8`，`all` 表示全部
 - `-t`, `--vol-type`: 卷类型，`vol`: 单行本（默认）；`extra`: 番外；`seri`: 连载话；`all`: 全部
+- `-f`, `--format`: 卷格式，`epub`（默认）；`mobi`
 - `-p`, `--proxy`: 代理服务器地址
 - `-r`, `--retry`: 下载失败时的重试次数，默认为 3
 - `-c`, `--callback`: 下载完成后的回调脚本（使用方式详见 [4. 回调函数](https://github.com/chrisis58/kmoe-manga-downlaoder?tab=readme-ov-file#4-%E5%9B%9E%E8%B0%83%E5%87%BD%E6%95%B0)）
@@ -155,7 +156,7 @@ kmdr config -s num_workers=5 "callback=echo '{b.name} {v.name} downloaded!' >> ~
 - `-d`, `--delete`, `--unset`: 清除单项配置
 
 > [!NOTE]
-> 当前仅支持部分下载参数的持久化：`num_workers`, `dest`, `retry`, `callback`, `proxy`
+> 当前仅支持部分下载参数的持久化：`format` ,`num_workers`, `dest`, `retry`, `callback`, `proxy`
 
 ### 6. 凭证池与故障转移 ![V1.3.0+](https://img.shields.io/badge/v1.3.0%2B-blue?style=flat-square)
 

--- a/src/kmdr/core/bases.py
+++ b/src/kmdr/core/bases.py
@@ -5,6 +5,8 @@ import asyncio
 from aiohttp import ClientSession
 from rich.prompt import Confirm
 
+from kmdr.core.constants import BookFormat
+
 from .console import *
 from .error import LoginError
 from .registry import Registry
@@ -90,10 +92,11 @@ class Picker(TerminalContext):
 
 
 class Downloader(SessionContext, TerminalContext):
-    def __init__(self, dest: str = ".", callback: Optional[str] = None, retry: int = 3, num_workers: int = 8, *args, **kwargs):
+    def __init__(self, dest: str = ".", format: str = "epub", callback: Optional[str] = None, retry: int = 3, num_workers: int = 8, *args, **kwargs):
         super().__init__(*args, **kwargs)
 
         self._dest: str = dest
+        self._format: BookFormat = BookFormat.from_name(format)
         self._callback: Optional[Callable] = construct_callback(callback)
         self._retry: int = retry
         self._semaphore = asyncio.Semaphore(num_workers)

--- a/src/kmdr/core/constants.py
+++ b/src/kmdr/core/constants.py
@@ -45,11 +45,25 @@ class _ApiRoute:
     BOOK_DATA: str = "/book_data.php"
     """书籍数据接口"""
 
-    DOWNLOAD: str = "/dl/{book_id}/{volume_id}/1/2/{is_vip}/"
-    """下载接口"""
+    DOWNLOAD: str = "/dl/{book_id}/{volume_id}/1/{book_format}/{is_vip}/"
+    """
+    下载接口
+    
+    :param book_id: 书籍 ID
+    :param volume_id: 卷 ID
+    :param book_format: 书籍格式，1 表示 mobi，2 表示 epub
+    :param is_vip: 是否为 VIP 书籍，1 表示是，0 表示否
+    """
 
-    GETDOWNURL: str = "/getdownurl.php?b={book_id}&v={volume_id}&mobi=2&vip={is_vip}&json=1"
-    """获取下载链接接口"""
+    GETDOWNURL: str = "/getdownurl.php?b={book_id}&v={volume_id}&mobi={book_format}&vip={is_vip}&json=1"
+    """
+    获取下载链接接口
+    
+    :param book_id: 书籍 ID
+    :param volume_id: 卷 ID
+    :param book_format: 书籍格式，1 表示 mobi，2 表示 epub
+    :param is_vip: 是否为 VIP 书籍，1 表示是，0 表示否
+    """
 
 
 class LoginResponse(Enum):
@@ -71,6 +85,18 @@ class LoginResponse(Enum):
         if isinstance(code, LoginResponse):
             return code == cls.m100
         return cls.from_code(code) == cls.m100
+
+
+class BookFormat(Enum):
+    EPUB = 2
+    MOBI = 1
+
+    @classmethod
+    def from_name(cls, name: str) -> "BookFormat":
+        ext = cls.__members__.get(name.upper())
+        if ext is None:
+            raise ValueError(f"未知的书籍格式：{name}")
+        return ext
 
 
 API_ROUTE = _ApiRoute()

--- a/src/kmdr/core/defaults.py
+++ b/src/kmdr/core/defaults.py
@@ -61,7 +61,7 @@ def argument_parser():
     download_parser.add_argument("-d", "--dest", type=str, help="指定下载文件的保存路径，默认为当前目录", required=False)
     download_parser.add_argument("-l", "--book-url", type=str, help="漫画详情页面的 URL", required=False)
     download_parser.add_argument("-v", "--volume", type=str, help="指定下载的卷，多个用逗号分隔，例如 `1,2,3` 或 `1-5,8`，`all` 表示全部", required=False)
-    download_parser.add_argument("-f", "--format", type=str, help="指定下载的漫画格式，`mobi` 或 `epub`", required=False, choices=["mobi", "epub"], default="epub")
+    download_parser.add_argument("-f", "--format", type=str, help="指定下载的漫画格式，`mobi` 或 `epub`，默认为 `epub`", required=False, choices=["mobi", "epub"])
     download_parser.add_argument("-t", "--vol-type", type=str, help="指定下载的卷类型，`vol` 为单行本, `extra` 为番外, `seri` 为连载", required=False, choices=["vol", "extra", "seri", "all"], default="vol")
     download_parser.add_argument("--max-size", type=float, help="限制下载卷的最大体积 (单位: MB)", required=False)
     download_parser.add_argument("--limit", type=int, help="限制下载卷的总数量", required=False)

--- a/src/kmdr/core/defaults.py
+++ b/src/kmdr/core/defaults.py
@@ -61,6 +61,7 @@ def argument_parser():
     download_parser.add_argument("-d", "--dest", type=str, help="指定下载文件的保存路径，默认为当前目录", required=False)
     download_parser.add_argument("-l", "--book-url", type=str, help="漫画详情页面的 URL", required=False)
     download_parser.add_argument("-v", "--volume", type=str, help="指定下载的卷，多个用逗号分隔，例如 `1,2,3` 或 `1-5,8`，`all` 表示全部", required=False)
+    download_parser.add_argument("-f", "--format", type=str, help="指定下载的漫画格式，`mobi` 或 `epub`", required=False, choices=["mobi", "epub"], default="epub")
     download_parser.add_argument("-t", "--vol-type", type=str, help="指定下载的卷类型，`vol` 为单行本, `extra` 为番外, `seri` 为连载", required=False, choices=["vol", "extra", "seri", "all"], default="vol")
     download_parser.add_argument("--max-size", type=float, help="限制下载卷的最大体积 (单位: MB)", required=False)
     download_parser.add_argument("--limit", type=int, help="限制下载卷的总数量", required=False)

--- a/src/kmdr/module/configurer/option_validate.py
+++ b/src/kmdr/module/configurer/option_validate.py
@@ -131,5 +131,6 @@ def validate_format(value: str) -> Optional[str]:
         fmt = BookFormat.from_name(value)
         return fmt.name.lower()
     except ValueError:
-        info(f"[red]无效的格式: {value}。可用格式：{', '.join(BookFormat.__members__.keys())}[/red]")
+        available_formats = ", ".join(fmt.name.lower() for fmt in BookFormat)
+        info(f"[red]无效的格式: {value}。可用格式：{available_formats}[/red]")
         return None

--- a/src/kmdr/module/configurer/option_validate.py
+++ b/src/kmdr/module/configurer/option_validate.py
@@ -4,6 +4,7 @@ import os
 
 from kmdr.core.console import info
 from kmdr.core.error import ValidationError
+from kmdr.core.constants import BookFormat
 
 __OPTIONS_VALIDATOR = {}
 
@@ -123,3 +124,12 @@ def validate_proxy(value: str) -> Optional[str]:
         info("[red]代理不能为空。[/red]")
         return None
     return value
+
+@register_validator("format")
+def validate_format(value: str) -> Optional[str]:
+    try:
+        fmt = BookFormat.from_name(value)
+        return fmt.name.lower()
+    except ValueError:
+        info(f"[red]无效的格式: {value}。可用格式：{', '.join(BookFormat.__members__.keys())}[/red]")
+        return None

--- a/src/kmdr/module/downloader/DirectDownloader.py
+++ b/src/kmdr/module/downloader/DirectDownloader.py
@@ -14,8 +14,8 @@ from .download_utils import (
 
 @DOWNLOADER.register(hasvalues={"method": 2})
 class DirectDownloader(Downloader):
-    def __init__(self, dest=".", callback=None, retry=3, num_workers=8, proxy=None, vip=False, disable_multi_part=False, *args, **kwargs):
-        super().__init__(dest, callback, retry, num_workers, proxy, *args, **kwargs)
+    def __init__(self, dest=".", format="epub", callback=None, retry=3, num_workers=8, proxy=None, vip=False, disable_multi_part=False, *args, **kwargs):
+        super().__init__(dest, format, callback, retry, num_workers, proxy, *args, **kwargs)
         self._use_vip = vip
         self._disable_multi_part = disable_multi_part
 
@@ -36,7 +36,7 @@ class DirectDownloader(Downloader):
                 self._progress,
                 partial(self.construct_download_url, cred, book, volume),
                 download_path,
-                readable_safe_filename(f"[Kmoe][{book.name}][{volume.name}].epub"),
+                readable_safe_filename(f"[Kmoe][{book.name}][{volume.name}].{self._format.name.lower()}"),
                 self._retry,
                 cookies=cred.cookies,
                 callback=lambda: self._callback(book, volume) if self._callback else None,
@@ -50,7 +50,7 @@ class DirectDownloader(Downloader):
             self._progress,
             partial(self.construct_download_url, cred, book, volume),
             download_path,
-            readable_safe_filename(f"[Kmoe][{book.name}][{volume.name}].epub"),
+            readable_safe_filename(f"[Kmoe][{book.name}][{volume.name}].{self._format.name.lower()}"),
             self._retry,
             cookies=cred.cookies,
             callback=lambda: self._callback(book, volume) if self._callback else None,
@@ -61,5 +61,6 @@ class DirectDownloader(Downloader):
         return API_ROUTE.DOWNLOAD.format(
             book_id=book.id,
             volume_id=volume.id,
+            book_format=self._format.value,
             is_vip=1 if self._use_vip and cred.is_vip else 0,
         )

--- a/src/kmdr/module/downloader/ReferViaDownloader.py
+++ b/src/kmdr/module/downloader/ReferViaDownloader.py
@@ -111,7 +111,7 @@ class ReferViaDownloader(Downloader):
                 book_id=book_id,
                 volume_id=volume_id,
                 book_format=self._format.value,
-                is_vip=is_vip if self._use_vip else 0,
+                is_vip=1 if (self._use_vip and is_vip) else 0,
             ),
             cookies=cookies,
         ) as response:

--- a/src/kmdr/module/downloader/ReferViaDownloader.py
+++ b/src/kmdr/module/downloader/ReferViaDownloader.py
@@ -27,6 +27,7 @@ class ReferViaDownloader(Downloader):
     def __init__(
         self,
         dest=".",
+        format="epub",
         callback=None,
         retry=3,
         num_workers=8,
@@ -37,7 +38,7 @@ class ReferViaDownloader(Downloader):
         *args,
         **kwargs,
     ):
-        super().__init__(dest, callback, retry, num_workers, proxy, *args, **kwargs)
+        super().__init__(dest, format, callback, retry, num_workers, proxy, *args, **kwargs)
         self._use_vip = vip
         self._disable_multi_part = disable_multi_part
         self._try_multi_part = try_multi_part
@@ -69,7 +70,7 @@ class ReferViaDownloader(Downloader):
                     volume.id,
                 ),
                 download_path,
-                readable_safe_filename(f"[Kmoe][{book.name}][{volume.name}].epub"),
+                readable_safe_filename(f"[Kmoe][{book.name}][{volume.name}].{self._format.name.lower()}"),
                 self._retry,
                 headers=DOWNLOAD_HEAD,
                 callback=lambda: self._callback(book, volume) if self._callback else None,
@@ -90,7 +91,7 @@ class ReferViaDownloader(Downloader):
                 volume.id,
             ),
             download_path,
-            readable_safe_filename(f"[Kmoe][{book.name}][{volume.name}].epub"),
+            readable_safe_filename(f"[Kmoe][{book.name}][{volume.name}].{self._format.name.lower()}"),
             self._retry,
             headers=DOWNLOAD_HEAD,
             callback=lambda: self._callback(book, volume) if self._callback else None,
@@ -109,6 +110,7 @@ class ReferViaDownloader(Downloader):
             API_ROUTE.GETDOWNURL.format(
                 book_id=book_id,
                 volume_id=volume_id,
+                book_format=self._format.value,
                 is_vip=is_vip if self._use_vip else 0,
             ),
             cookies=cookies,

--- a/tests/test_kmdr_download.py
+++ b/tests/test_kmdr_download.py
@@ -99,6 +99,7 @@ class TestKmdrDownload(unittest.TestCase):
                 vol_type="extra",
                 volume="all",
                 max_size=0.6,
+                format="mobi",
                 limit=1,
                 retry=3,
             )
@@ -107,6 +108,7 @@ class TestKmdrDownload(unittest.TestCase):
         assert len(sub_dir := os.listdir(dest)) == 1, "Expected one subdirectory in the destination"
         assert os.path.isdir(os.path.join(dest, book_dir := sub_dir[0])), "Expected the subdirectory to be a directory"
         assert len(os.listdir(os.path.join(dest, book_dir))) == 1, "Expected 1 volume to be downloaded"
+        assert any(f.endswith(".mobi") for f in os.listdir(os.path.join(dest, book_dir))), "Expected downloaded file to be in mobi format"
 
         total_size = sum(
             os.path.getsize(os.path.join(dest, book_dir, f))


### PR DESCRIPTION
### 相关内容

#39 

### 主要变动

#### 1. 添加选项

为 `download` 命令添加 `-f` | `--format` 的选项，用于选择下载的格式。
可供选择的选项：
1. epub（默认）
2. mobi 

#### 2. 支持持久化 format 配置

可以使用以下命令持久化格式的选项：

```bash
kmdr config -s format=mobi
```