### PR TITLE
fix: 适配最新的登录接口响应格式

### DIFF
--- a/src/kmdr/core/constants.py
+++ b/src/kmdr/core/constants.py
@@ -36,7 +36,7 @@ class _ApiRoute:
     LOGIN: str = "/login.php"
     """登录页面"""
 
-    LOGIN_DO: str = "/login_do.php"
+    LOGIN_DO: str = "/login_act.php"
     """登录接口"""
 
     MY_FOLLOW: str = "/myfollow.php"

--- a/src/kmdr/module/authenticator/LoginAuthenticator.py
+++ b/src/kmdr/module/authenticator/LoginAuthenticator.py
@@ -1,4 +1,3 @@
-import re
 from typing import Optional
 
 from rich.prompt import Prompt
@@ -39,15 +38,19 @@ class LoginAuthenticator(Authenticator):
         async with self._session.post(
             url=API_ROUTE.LOGIN_DO,
             data={"email": self._username, "passwd": self._password, "keepalive": "on"},
+            headers={"Referer": API_ROUTE.LOGIN},
         ) as response:
             response.raise_for_status()
 
-            match = re.search(r'"\w+"', await response.text())
-
-            if not match:
+            try:
+                result = await response.json(content_type=None)
+            except ValueError:
                 raise LoginError("无法解析登录响应。")
 
-            code = match.group(0).split('"')[1]
+            code = result.get("msgid", "")
+
+            if not code:
+                raise LoginError("无法解析登录响应。")
 
             login_response = LoginResponse.from_code(code)
             if not LoginResponse.ok(login_response):


### PR DESCRIPTION
- 修正登录端点 URL 从 /login_do.php 到 /login_act.php
- 将正则解析改为 JSON 解析，直接提取 msgid 字段 旧格式 `"m100"` 与新格式 `{"ret":1,"msgid":"m100"}` 兼容
- 新增 Referer 请求头绕过反爬检测